### PR TITLE
matlab/octave

### DIFF
--- a/lol_qwop.m
+++ b/lol_qwop.m
@@ -1,0 +1,2 @@
+% matlab / octave script %
+fprintf('lol-qwop\n')


### PR DESCRIPTION
file name format lol_qwop.m since we cannot use hypen for script file name in matlab/octave